### PR TITLE
Fallback to loqus id if there is only one sattelite id, and no variant_id

### DIFF
--- a/src/abacus/locus.py
+++ b/src/abacus/locus.py
@@ -85,8 +85,13 @@ def load_loci_from_json(json_path: Path, ref_path: Path) -> list[Locus]:
         locus_location, satellite_locations = process_region(reference_region)
 
         # Get satellite ids
-        satellite_ids = item["VariantId"] if "VariantId" in item else [f"{locus_id}.{i + 1}" for i in range(len(satellite_seqs))]
-
+        if "VariantId" in item:
+            satellite_ids = item["VariantId"]
+        elif len(satellite_seqs) == 1:
+            satellite_ids = [f"{locus_id}"]
+        else:
+            satellite_ids = [f"{locus_id}.{i + 1}" for i in range(len(satellite_seqs))]
+        
         # Create satellites
         satellites = create_satellites(satellite_seqs, satellites_skippable, satellite_locations, satellite_ids, locus_id)
 


### PR DESCRIPTION
- Fix https://github.com/MOMA-AUH/abacus/issues/7

Before
```
END=57367118;LOCUSID=DAB1;RU=AAAAT;REPID=DAB1_ATTTT2
END=94418442;LOCUSID=ABCD3;RU=GCC;REPID=ABCD3.1
END=149390841;LOCUSID=NOTCH2NLC;RU=GGC;REPID=NOTCH2NLC.1
```

After
```
END=57367118;LOCUSID=DAB1;RU=AAAAT;REPID=DAB1_ATTTT2
END=94418442;LOCUSID=ABCD3;RU=GCC;REPID=ABCD3
END=149390841;LOCUSID=NOTCH2NLC;RU=GGC;REPID=NOTCH2NLC
```
